### PR TITLE
changed to s.je

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     updatecerts:
         image: vjedev/certupdater:latest
         volumes:
-            - certs:/certs
+            - ./certs:/certs
     landingpage:
         image: vjedev/landingpage:latest
         volumes:
@@ -14,9 +14,6 @@ services:
             - ./websites:/websites
         links:
             - mysql
-        networks:
-            vpcbr:
-                ipv4_address: 192.168.56.5
     web:
         image: nginx:latest
         ports:
@@ -24,22 +21,18 @@ services:
             - "443:443"
         volumes:
             - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
-            - certs:/certs
+            - ./certs:/certs
             - ./websites:/websites
         links:
             - php
-        networks:
-            vpcbr:
-                ipv4_address: 192.168.56.2
+        depends_on:
+            - updatecerts
     php:
         build:
             context: .
             dockerfile: PHP.Dockerfile
         volumes:
             - ./websites:/websites
-        networks:
-            vpcbr:
-                ipv4_address: 192.168.56.3
     mysql:
         image: mariadb:latest
         environment:
@@ -49,18 +42,7 @@ services:
         volumes:
             - mysqldata:/var/lib/mysql
         ports:
-            - 3306:3306
-        networks:
-            vpcbr:
-                ipv4_address: 192.168.56.4
-networks:
-    vpcbr:
-        driver: bridge
-        ipam:
-            config:
-             - subnet: 192.168.56.0/24
-               gateway: 192.168.56.1
-                    
+            - 3306:3306                   
 volumes:
     mysqldata: {}
     certs: {}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,19 +1,19 @@
 server {
     listen 80;
-    server_name v.je 192.168.56.2;
-    return 301 https://v.je$request_uri;
+    server_name s.je;
+    return 301 https://s.je$request_uri;
 }
 
 server {
     listen 443 ssl http2;   
-    server_name 192.168.56.2 v.je;
+    server_name s.je;
     root /websites/default/public;
     index index.php index.html index.htm;
     
-    ssl_certificate /certs/v.je/fullchain.pem;
-    ssl_certificate_key /certs/v.je/privkey.pem;    
+    ssl_certificate /certs/s.je/fullchain.pem;
+    ssl_certificate_key /certs/s.je/privkey.pem;    
     ssl_session_cache shared:SSL:10m;
-    ssl_trusted_certificate /certs/v.je/chain.pem;
+    ssl_trusted_certificate /certs/s.je/chain.pem;
     ssl_stapling on;
     ssl_stapling_verify on;
     resolver 1.1.1.1;
@@ -49,20 +49,20 @@ server {
 
 server {
     listen 80;
-    server_name ~^(?<subdomain>.*)\.v\.je$;
-    return 301 https://$subdomain.v.je$request_uri;
+    server_name ~^(?<subdomain>.*)\.s\.je$;
+    return 301 https://$subdomain.s.je$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name ~^(?<subdomain>.+)\.v\.je$;
+    server_name ~^(?<subdomain>.+)\.s\.je$;
     root /websites/$subdomain/public;
     index index.php index.html index.htm;
     
-    ssl_certificate /certs/v.je-0001/fullchain.pem;
-    ssl_certificate_key /certs/v.je-0001/privkey.pem;   
+    ssl_certificate /certs/s.je-0001/fullchain.pem;
+    ssl_certificate_key /certs/s.je-0001/privkey.pem;   
     ssl_session_cache shared:SSL:10m;
-    ssl_trusted_certificate /certs/v.je-0001/chain.pem;
+    ssl_trusted_certificate /certs/s.je-0001/chain.pem;
     ssl_stapling on;
     ssl_stapling_verify on;
     resolver 1.1.1.1;


### PR DESCRIPTION
Until v.je is no longer in use by this year's students who need vagrant, s.je will be the primary domain for the docker version. The v.je branch works as a drop-in replacement for the v.je vagrant box but requires manually configured static IP addresses to do so.